### PR TITLE
[M-2368] Samsung z-fold: turning camera on causes app freeze

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
+++ b/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
@@ -4,6 +4,8 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.media.projection.MediaProjectionManager;
+import android.os.Handler;
+import android.os.Looper;
 import android.util.DisplayMetrics;
 import android.util.Log;
 import androidx.core.util.Consumer;
@@ -402,8 +404,9 @@ class GetUserMediaImpl {
 
         track.setEnabled(true);
         tracks.put(videoTrackId, new TrackPrivate(track, videoSource, videoCaptureController, surfaceTextureHelper));
-
-        videoCaptureController.startCapture();
+        
+        // Delay fix issue with app freezing on fold devices
+        new Handler(Looper.getMainLooper()).postDelayed(videoCaptureController::startCapture, 250);
 
         return track;
     }


### PR DESCRIPTION
# BUG

**Task**: [M-2368](https://yt.sharekey.com/issue/M-2368) Samsung z-fold: turning camera on causes app freeze


## Issue cause 

Camera2Session: Error: Failed to start capture request. 
android.hardware.camera2.CameraAccessException: CAMERA_ERROR (3): 
createDefaultRequest:1648: Camera 1: Error creating default request for template 3: Function not implemented (-38)

## What was done

Start capture with delay
