### PR TITLE
M-2398 Add PeerConnection "finish" method to avoid "close" delays due to Audio manipulations

### DIFF
--- a/ios/RCTWebRTC/WebRTCModule+RTCAudioSession.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCAudioSession.m
@@ -4,6 +4,7 @@
 #import <React/RCTBridgeModule.h>
 
 #import "WebRTCModule.h"
+#import "WebRTCAudioSession.h"
 
 @implementation WebRTCModule (RTCAudioSession)
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(unlockPeerClosing) {

--- a/ios/RCTWebRTC/WebRTCModule+RTCAudioSession.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCAudioSession.m
@@ -6,6 +6,17 @@
 #import "WebRTCModule.h"
 
 @implementation WebRTCModule (RTCAudioSession)
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(unlockPeerClosing) {
+    WebRTCAudioSession* session = [WebRTCAudioSession shared];
+    [session setAudioSessionEnabled:NO];
+    return nil;
+}
+
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(lockPeerClosing) {
+    WebRTCAudioSession* session = [WebRTCAudioSession shared];
+    [session setAudioSessionEnabled:YES];
+    return nil;
+}
 
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(audioSessionDidActivate) {
     [[RTCAudioSession sharedInstance] audioSessionDidActivate:[AVAudioSession sharedInstance]];

--- a/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.m
@@ -356,11 +356,7 @@ RCT_EXPORT_METHOD(peerConnectionClose : (nonnull NSNumber *)objectID) {
         return;
     }
 
-  WebRTCAudioSession* session = [WebRTCAudioSession shared];
-
-  [session closeConnection:^{
     [peerConnection close];
-  }];
 }
 
 RCT_EXPORT_METHOD(peerConnectionDispose : (nonnull NSNumber *)objectID) {

--- a/src/RTCAudioSession.ts
+++ b/src/RTCAudioSession.ts
@@ -4,6 +4,26 @@ const { WebRTCModule } = NativeModules;
 
 export default class RTCAudioSession {
     /**
+     * To be called when close peer connection to fix issue with no mic sound in group call when
+     */
+    static unlockPeerClosing() {
+        // Only valid for iOS
+        if (Platform.OS === 'ios') {
+            WebRTCModule.unlockPeerClosing();
+        }
+    }
+
+    /**
+     * To be called when peer connection closed to fix issue with no mic sound in group call when
+     */
+    static lockPeerClosing() {
+        // Only valid for iOS
+        if (Platform.OS === 'ios') {
+            WebRTCModule.lockPeerClosing();
+        }
+    }
+
+    /**
      * To be called when CallKit activates the audio session.
      */
     static audioSessionDidActivate() {


### PR DESCRIPTION
[M-2398](https://yt.sharekey.com/issue/M-2398) Add PeerConnection "finish" method to avoid "close" delays due to Audio manipulations

Optimization peer closing, use lock/unlock methods to prevent issue when peers not closed immediately

Mobile PR: https://github.com/sharekey/mobile/pull/3409