### PR TITLE
fix: Check null before use objects and add runOnExecutor

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/PeerConnectionObserver.java
+++ b/android/src/main/java/com/oney/WebRTCModule/PeerConnectionObserver.java
@@ -69,11 +69,23 @@ class PeerConnectionObserver implements PeerConnection.Observer {
     void close() {
         Log.d(TAG, "PeerConnection.close() for " + id);
 
-        peerConnection.close();
+        PeerConnection pc = peerConnection;
+        if (pc == null) {
+            return;
+        }
+
+        pc.close();
     }
 
     void dispose() {
         Log.d(TAG, "PeerConnection.dispose() for " + id);
+
+        PeerConnection pc = peerConnection;
+        if (pc == null) {
+            return;
+        }
+        // Make future calls observe disposal immediately.
+        peerConnection = null;
 
         // Remove video track adapters
         for (MediaStreamTrack track : this.remoteTracks.values()) {
@@ -91,7 +103,7 @@ class PeerConnectionObserver implements PeerConnection.Observer {
         // At this point there should be no local MediaStreams in the associated
         // PeerConnection. Call dispose() to free all remaining resources held
         // by the PeerConnection instance (RtpReceivers, RtpSenders, etc.)
-        peerConnection.dispose();
+        pc.dispose();
 
         remoteStreamIds.clear();
         remoteStreams.clear();

--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
@@ -518,6 +518,11 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
         for (int i = 0; i < mPeerConnectionObservers.size(); i++) {
             int key = mPeerConnectionObservers.keyAt(i);
             PeerConnectionObserver peer = mPeerConnectionObservers.get(key);
+
+            if (peer == null) {
+                continue;
+            }
+
             silenceIncomingCount.put(peer.getId(), 0);
         }
 
@@ -527,76 +532,97 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
         WebRTCModule.voiceTimer.schedule(new TimerTask() {
             @Override
             public void run() {
-                for (int i = 0; i < mPeerConnectionObservers.size(); i++) {
-                    int key = mPeerConnectionObservers.keyAt(i);
-                    PeerConnectionObserver peer = mPeerConnectionObservers.get(key);
-                    int id = peer.getId();
+                ThreadUtils.runOnExecutor(() -> {
+                    for (int i = 0; i < mPeerConnectionObservers.size(); i++) {
+                        int key = mPeerConnectionObservers.keyAt(i);
+                        PeerConnectionObserver peer = mPeerConnectionObservers.get(key);
 
-                    if (peer.getPeerConnection().connectionState() == PeerConnection.PeerConnectionState.CONNECTED) {
-                        peer.getPeerConnection().getStats(new RTCStatsCollectorCallback() {
-                            @Override
-                            public void onStatsDelivered(RTCStatsReport rtcStatsReport) {
+                        if (peer == null) {
+                            continue;
+                        }
 
-                                for (RTCStats stats : rtcStatsReport.getStatsMap().values()) {
-                                    if (stats.getType().equals("inbound-rtp")) {
-                                        Object audioLevelObject = stats.getMembers().get("audioLevel");
+                        int id = peer.getId();
 
-                                        if (audioLevelObject instanceof Double) {
-                                            Double audioLevel = ((Double) audioLevelObject);
+                        PeerConnection peerConnection = peer.getPeerConnection();
 
-                                            if (audioLevel > 0.025) {
-                                                silenceIncomingCount.put(id, 0);
-                                                incomingAudioLevelHolder.setValue(peer, true, audioLevel.doubleValue());
-                                            } else {
-                                                silenceIncomingCount.put(id, silenceIncomingCount.get(id) + 1);
+                        if (peerConnection == null) {
+                            continue;
+                        }
 
-                                                if (silenceIncomingCount.get(id) > 4.0) {
-                                                    incomingAudioLevelHolder.setValue(peer, false, 0);
+                        if (peerConnection.connectionState() == PeerConnection.PeerConnectionState.CONNECTED) {
+                            peerConnection.getStats(new RTCStatsCollectorCallback() {
+                                @Override
+                                public void onStatsDelivered(RTCStatsReport rtcStatsReport) {
+
+                                    for (RTCStats stats : rtcStatsReport.getStatsMap().values()) {
+                                        if (stats.getType().equals("inbound-rtp")) {
+                                            Object audioLevelObject = stats.getMembers().get("audioLevel");
+
+                                            if (audioLevelObject instanceof Double) {
+                                                Double audioLevel = ((Double) audioLevelObject);
+
+                                                if (audioLevel > 0.025) {
+                                                    silenceIncomingCount.put(id, 0);
+                                                    incomingAudioLevelHolder.setValue(peer, true, audioLevel.doubleValue());
+                                                } else {
+                                                    silenceIncomingCount.put(id, silenceIncomingCount.get(id) + 1);
+
+                                                    if (silenceIncomingCount.get(id) > 4.0) {
+                                                        incomingAudioLevelHolder.setValue(peer, false, 0);
+                                                    }
                                                 }
                                             }
                                         }
                                     }
                                 }
-                            }
-                        });
+                            });
+                        }
                     }
-                }
 
-                for (int i = 0; i < mPeerConnectionObservers.size(); i++) {
-                    int key = mPeerConnectionObservers.keyAt(i);
-                    PeerConnectionObserver peer = mPeerConnectionObservers.get(key);
+                    for (int i = 0; i < mPeerConnectionObservers.size(); i++) {
+                        int key = mPeerConnectionObservers.keyAt(i);
+                        PeerConnectionObserver peer = mPeerConnectionObservers.get(key);
+                        if (peer == null) {
+                            continue;
+                        }
 
-                    if (peer.getPeerConnection().connectionState() == PeerConnection.PeerConnectionState.CONNECTED) {
-                        peer.getPeerConnection().getStats(new RTCStatsCollectorCallback() {
-                            @Override
-                            public void onStatsDelivered(RTCStatsReport rtcStatsReport) {
+                        PeerConnection peerConnection = peer.getPeerConnection();
+                        if (peerConnection == null) {
+                            continue;
+                        }
 
-                                for (RTCStats stats : rtcStatsReport.getStatsMap().values()) {
-                                    if (stats.getType().equals("media-source")) {
-                                        Object audioLevelObject = stats.getMembers().get("audioLevel");
+                        if (peerConnection.connectionState() == PeerConnection.PeerConnectionState.CONNECTED) {
+                            peerConnection.getStats(new RTCStatsCollectorCallback() {
+                                @Override
+                                public void onStatsDelivered(RTCStatsReport rtcStatsReport) {
 
-                                        if (audioLevelObject instanceof Double) {
-                                            Double audioLevel = ((Double) audioLevelObject);
+                                    for (RTCStats stats : rtcStatsReport.getStatsMap().values()) {
+                                        if (stats.getType().equals("media-source")) {
+                                            Object audioLevelObject = stats.getMembers().get("audioLevel");
 
-                                            if (audioLevel > 0.01) {
-                                                silenceOutgoingCount[0] = 0;
-                                                outgoingAudioLevelHolder.setValue(peer, true, audioLevel.doubleValue());
-                                            } else {
-                                                silenceOutgoingCount[0] += 1;
+                                            if (audioLevelObject instanceof Double) {
+                                                Double audioLevel = ((Double) audioLevelObject);
 
-                                                if (silenceOutgoingCount[0] > 4.0) {
-                                                    outgoingAudioLevelHolder.setValue(peer, false, 0);
+                                                if (audioLevel > 0.01) {
+                                                    silenceOutgoingCount[0] = 0;
+                                                    outgoingAudioLevelHolder.setValue(peer, true, audioLevel.doubleValue());
+                                                } else {
+                                                    silenceOutgoingCount[0] += 1;
+
+                                                    if (silenceOutgoingCount[0] > 4.0) {
+                                                        outgoingAudioLevelHolder.setValue(peer, false, 0);
+                                                    }
                                                 }
                                             }
                                         }
                                     }
                                 }
-                            }
-                        });
+                            });
 
-                        return;
+                            return;
+                        }
                     }
-                }
+                });
             }
         }, 0, checkInterval);
 
@@ -1542,7 +1568,11 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
             if (pco == null || pco.getPeerConnection() == null) {
                 Log.d(TAG, "peerConnectionDispose() peerConnection is null");
             }
-            pco.dispose();
+
+            if (pco != null) {
+                pco.dispose();
+            }
+
             mPeerConnectionObservers.remove(id);
 
             if (mPeerConnectionObservers.size() == 0) {

--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
@@ -43,6 +43,9 @@ import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 interface OnValueChangeListener {
     void onValueChanged(PeerConnectionObserver peerConnection, boolean isSpeaking, double audioLevel);
@@ -100,6 +103,10 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
 
     AudioLevelValueHolder incomingAudioLevelHolder;
     AudioLevelValueHolder outgoingAudioLevelHolder;
+
+    private final AtomicInteger voicePollGeneration = new AtomicInteger(0);
+    private final AtomicReference<Future<?>> voicePollTaskRef = new AtomicReference<>(null);
+
 
     private final GetUserMediaImpl getUserMediaImpl;
 
@@ -499,6 +506,14 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
     }
 
     void cancelVoiceActivity() {
+        // Invalidate all queued/running poll tasks from previous timer cycle.
+        voicePollGeneration.incrementAndGet();
+
+        Future<?> pending = voicePollTaskRef.getAndSet(null);
+        if (pending != null) {
+            pending.cancel(false);
+        }
+
         if (WebRTCModule.voiceTimer != null) {
             WebRTCModule.voiceTimer.cancel();
             WebRTCModule.voiceTimer.purge();
@@ -509,6 +524,7 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
         outgoingAudioLevelHolder.cleanup();
     }
 
+
     void observeVoiceActivity() {
         int checkInterval = 300;
 
@@ -518,42 +534,50 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
         for (int i = 0; i < mPeerConnectionObservers.size(); i++) {
             int key = mPeerConnectionObservers.keyAt(i);
             PeerConnectionObserver peer = mPeerConnectionObservers.get(key);
-
-            if (peer == null) {
-                continue;
+            if (peer != null) {
+                silenceIncomingCount.put(peer.getId(), 0);
             }
-
-            silenceIncomingCount.put(peer.getId(), 0);
         }
 
         cancelVoiceActivity();
+        final int generation = voicePollGeneration.incrementAndGet();
 
         WebRTCModule.voiceTimer = new Timer();
         WebRTCModule.voiceTimer.schedule(new TimerTask() {
             @Override
             public void run() {
-                ThreadUtils.runOnExecutor(() -> {
+                if (voicePollGeneration.get() != generation) {
+                    return;
+                }
+
+                Future<?> current = voicePollTaskRef.get();
+                if (current != null && !current.isDone()) {
+                    return; // previous tick still queued/running
+                }
+
+                Future<?> next = ThreadUtils.submitToExecutor(() -> {
+                    if (voicePollGeneration.get() != generation) {
+                        return;
+                    }
+
                     for (int i = 0; i < mPeerConnectionObservers.size(); i++) {
                         int key = mPeerConnectionObservers.keyAt(i);
                         PeerConnectionObserver peer = mPeerConnectionObservers.get(key);
-
                         if (peer == null) {
+                            continue;
+                        }
+
+                        PeerConnection peerConnection = peer.getPeerConnection();
+                        if (peerConnection == null) {
                             continue;
                         }
 
                         int id = peer.getId();
 
-                        PeerConnection peerConnection = peer.getPeerConnection();
-
-                        if (peerConnection == null) {
-                            continue;
-                        }
-
                         if (peerConnection.connectionState() == PeerConnection.PeerConnectionState.CONNECTED) {
                             peerConnection.getStats(new RTCStatsCollectorCallback() {
                                 @Override
                                 public void onStatsDelivered(RTCStatsReport rtcStatsReport) {
-
                                     for (RTCStats stats : rtcStatsReport.getStatsMap().values()) {
                                         if (stats.getType().equals("inbound-rtp")) {
                                             Object audioLevelObject = stats.getMembers().get("audioLevel");
@@ -595,7 +619,6 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
                             peerConnection.getStats(new RTCStatsCollectorCallback() {
                                 @Override
                                 public void onStatsDelivered(RTCStatsReport rtcStatsReport) {
-
                                     for (RTCStats stats : rtcStatsReport.getStatsMap().values()) {
                                         if (stats.getType().equals("media-source")) {
                                             Object audioLevelObject = stats.getMembers().get("audioLevel");
@@ -623,6 +646,8 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
                         }
                     }
                 });
+
+                voicePollTaskRef.set(next);
             }
         }, 0, checkInterval);
 


### PR DESCRIPTION
[M-2740](https://yt.sharekey.com/issue/M-2740) Android: app stuck and then crashes, when finish a group call

1. Fix null pointer access, prevent use null objects when observe voice
2. Prevent using multithreaded when observe voice